### PR TITLE
Add `Net.Generic_Receiver` to simplify applications.

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "enet"
 description = "Ada Embedded Network Stack"
-version = "0.1.0-dev"
+version = "1.0.0"
 
 authors = ["Stephane Carrez"]
 maintainers = ["Stephane Carrez <Stephane.Carrez@gmail.com>", "Max Reznik <reznikmm@gmail.com>"]

--- a/src/net-generic_receiver.adb
+++ b/src/net-generic_receiver.adb
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------
 --  receiver -- Ethernet Packet Receiver
---  Copyright (C) 2016, 2017 Stephane Carrez
+--  Copyright (C) 2016-2024 Stephane Carrez
 --  Written by Stephane Carrez (Stephane.Carrez@gmail.com)
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,15 +21,17 @@ with Net.Buffers;
 with Net.Protos.Arp;
 with Net.Protos.Dispatchers;
 with Net.Headers;
-with Demos;
-package body Receiver is
 
-   use type Net.Ip_Addr;
-   use type Net.Uint8;
-   use type Net.Uint16;
+package body Net.Generic_Receiver is
 
    Ready  : Ada.Synchronous_Task_Control.Suspension_Object;
    ONE_US : constant Ada.Real_Time.Time_Span := Ada.Real_Time.Microseconds (1);
+
+   ETHERTYPE_ARP : constant Net.Uint16 :=
+     Net.Headers.To_Network (Net.Protos.ETHERTYPE_ARP);
+
+   ETHERTYPE_IP : constant Net.Uint16 :=
+     Net.Headers.To_Network (Net.Protos.ETHERTYPE_IP);
 
    --  ------------------------------
    --  Start the receiver loop.
@@ -62,13 +64,13 @@ package body Receiver is
             Net.Buffers.Allocate (Packet);
          end if;
          if not Packet.Is_Null then
-            Demos.Ifnet.Receive (Packet);
+            Ifnet.Receive (Packet);
             Now := Ada.Real_Time.Clock;
             Ether := Packet.Ethernet;
-            if Ether.Ether_Type = Net.Headers.To_Network (Net.Protos.ETHERTYPE_ARP) then
-               Net.Protos.Arp.Receive (Demos.Ifnet, Packet);
-            elsif Ether.Ether_Type = Net.Headers.To_Network (Net.Protos.ETHERTYPE_IP) then
-               Net.Protos.Dispatchers.Receive (Demos.Ifnet, Packet);
+            if Ether.Ether_Type = ETHERTYPE_ARP then
+               Net.Protos.Arp.Receive (Ifnet, Packet);
+            elsif Ether.Ether_Type = ETHERTYPE_IP then
+               Net.Protos.Dispatchers.Receive (Ifnet, Packet);
             end if;
 
             --  Compute the time taken to process the packet in microseconds.
@@ -90,4 +92,4 @@ package body Receiver is
       end loop;
    end Controller;
 
-end Receiver;
+end Net.Generic_Receiver;

--- a/src/net-generic_receiver.ads
+++ b/src/net-generic_receiver.ads
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------
 --  receiver -- Ethernet Packet Receiver
---  Copyright (C) 2016, 2017 Stephane Carrez
+--  Copyright (C) 2016-2024 Stephane Carrez
 --  Written by Stephane Carrez (Stephane.Carrez@gmail.com)
 --
 --  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,28 @@
 --  See the License for the specific language governing permissions and
 --  limitations under the License.
 -----------------------------------------------------------------------
-with Demos;
-with Net.Generic_Receiver;
+with System;
 with Net.Interfaces;
 
-package Receiver is new Net.Generic_Receiver
- (Ifnet => Net.Interfaces.Ifnet_Type'Class (Demos.Ifnet));
+generic
+   Ifnet : in out Net.Interfaces.Ifnet_Type'Class;
+   Storage_Size : Positive := 16 * 1024;
+   Priority : System.Priority := System.Default_Priority;
+package Net.Generic_Receiver is
+
+   type Us_Time is new Natural;
+
+   --  Average, min and max time in microseconds taken to process a packet.
+   Avg_Receive_Time : Us_Time := 0 with Atomic;
+   Min_Receive_Time : Us_Time := 0 with Atomic;
+   Max_Receive_Time : Us_Time := 0 with Atomic;
+
+   --  Start the receiver loop.
+   procedure Start;
+
+   --  The task that waits for packets.
+   task Controller with
+     Storage_Size => Storage_Size,
+     Priority => Priority;
+
+end Net.Generic_Receiver;


### PR DESCRIPTION
Hello @stcarrez !

How do you think if this good to have a generic `Receiver` in the core of ENet library?

Also I would like to release it as a crate (version 1.0.0) into alire index, if you don't mind. I mean target independent code only. STM32 driver depends on STM32 internals and there is no corresponding crate for them. My proposal to have a "virtual" crate for STM32 wasn't accepted, unfortunately. I hope we can push STM32 driver latter when we found a solution. Having target independent crate in the alire index would be great anyway.