### PR TITLE
Don't compile `net-uint32_randoms.ads`

### DIFF
--- a/gnat/enet.gpr
+++ b/gnat/enet.gpr
@@ -14,6 +14,17 @@ project Enet is
      external ("ENET_LIBRARY_TYPE", external ("LIBRARY_TYPE", "static"));
    for Library_Kind use Library_Type;
 
+   Excluded_Files := ();
+
+   case Enet_Config.Default_Random is
+      when "null" =>
+         Excluded_Files := Excluded_Files & ("net-uint32_randoms.ads");
+      when others =>
+         null;
+   end case;
+
+   for Excluded_Source_Files use Excluded_Files;
+
    package Compiler is
       for Default_Switches ("Ada") use Enet_Config.Ada_Compiler_Switches
         & ("-gnaty-I",  --  Turn off: check mode in


### PR DESCRIPTION
when Default_Random="null". The "light-tasking" runtime doesn't contain `Ada.Numerics.Discrete_Random`, so the compilation fails even when `Default_Random="null"`. Let's exclude this module for this case.