### PR TITLE
Avoid crash on 180MHz boards.

### DIFF
--- a/drivers/enet_stm32/src/net-stm32_interfaces.adb
+++ b/drivers/enet_stm32/src/net-stm32_interfaces.adb
@@ -590,7 +590,7 @@ package body Net.STM32_Interfaces is
             when 100e6 .. 150e6 - 1 => 2#001#,   --  AHB clock / 62
             when  20e6 ..  35e6 - 1 => 2#010#,   --  AHB clock / 16
             when  35e6 ..  60e6 - 1 => 2#011#,   --  AHB clock / 26
-            when 150e6 .. 180e6 - 1 => 2#100#,   --  AHB clock / 102
+            when 150e6 .. 240e6 - 1 => 2#100#,   --  AHB clock / 102
             when others => raise Program_Error);
    end Set_Clock_Frequency;
 


### PR DESCRIPTION
I by mistake excluded 180MHz from allowed clock range cases. This is the fix. But I decided to make the last range wider, just in case someone has overclocked board.