### PR TITLE
UDP socket unbind and disable/enable for stm32 eth

### DIFF
--- a/src/net-sockets-udp.adb
+++ b/src/net-sockets-udp.adb
@@ -35,6 +35,30 @@ package body Net.Sockets.Udp is
       Endpoint.Listen.Addr := Ifnet.Ip;
    end Bind;
 
+   procedure Unbind (Endpoint : access Socket'Class) is
+   begin
+      --  Delete socked from List
+      if List = Endpoint then
+         List := Endpoint.Next;
+      else
+         declare
+            Next : access Socket'Class := List;
+         begin
+            while Next /= null loop
+               if Next.Next = Endpoint then
+                  Next.Next := Endpoint.Next;
+                  Next := null;
+               else
+                  Next := Next.Next;
+               end if;
+            end loop;
+         end;
+      end if;
+
+      Endpoint.Ifnet := null;
+      Endpoint.Next := null;
+   end Unbind;
+
    procedure Send (Endpoint : in out Socket;
                    To       : in Sockaddr_In;
                    Packet   : in out Net.Buffers.Buffer_Type;

--- a/src/net-sockets-udp.ads
+++ b/src/net-sockets-udp.ads
@@ -25,6 +25,8 @@ package Net.Sockets.Udp is
                    Ifnet    : access Net.Interfaces.Ifnet_Type'Class;
                    Addr     : in Sockaddr_In);
 
+   procedure Unbind (Endpoint : access Socket'Class);
+
    --  Send the UDP packet to the destination IP and port.
    procedure Send (Endpoint : in out Socket;
                    To       : in Sockaddr_In;


### PR DESCRIPTION
In my application I need to shutdown/restart network. In this PR I've added `Unbind` for UDP socket and `Disable`/`Enable` for STM32 Eth interface. I also added `Wait` parameter to `Configure` to avoid loop waiting for the reset completion, because I want to have some timeout.