### PR TITLE
Avoid interrupt loss

### DIFF
--- a/drivers/enet_stm32/src/net-stm32_interfaces.adb
+++ b/drivers/enet_stm32/src/net-stm32_interfaces.adb
@@ -219,7 +219,7 @@ package body Net.STM32_Interfaces is
 
          Ethernet_DMA_Periph.DMAOMR.ST := True;
          if Ethernet_DMA_Periph.DMASR.TBUS then
-            Ethernet_DMA_Periph.DMASR.TBUS := True;
+            Ethernet_DMA_Periph.DMASR := (TBUS => True, others => <>);
          end if;
          if Ethernet_DMA_Periph.DMASR.TPS = 6 then
             Ethernet_DMA_Periph.DMAOMR.ST := False;
@@ -448,16 +448,16 @@ package body Net.STM32_Interfaces is
       procedure Interrupt is
       begin
          if Ethernet_DMA_Periph.DMASR.RS then
-            Ethernet_DMA_Periph.DMASR.RS := True;
+            Ethernet_DMA_Periph.DMASR := (RS => True, others => <>);
             Receive_Queue.Receive_Interrupt;
          end if;
          if Ethernet_DMA_Periph.DMASR.TS then
-            Ethernet_DMA_Periph.DMASR.TS := True;
+            Ethernet_DMA_Periph.DMASR := (TS => True, others => <>);
             Transmit_Queue.Transmit_Interrupt;
          elsif Ethernet_DMA_Periph.DMASR.TBUS then
-            Ethernet_DMA_Periph.DMASR.TBUS := True;
+            Ethernet_DMA_Periph.DMASR := (TBUS => True, others => <>);
          end if;
-         Ethernet_DMA_Periph.DMASR.NIS := True;
+         Ethernet_DMA_Periph.DMASR := (NIS => True, others => <>);
       end Interrupt;
 
       --  ------------------------------


### PR DESCRIPTION
As documentation says:

> Writing 1 to (unreserved) bits in ETH_DMASR register[16:0] clears them and
> writing 0 has no effect.

But when we do `Periph.DMASR.RS := True;` we actually do `Periph.DMASR := (RS => True, TS => Periph.DMASR.TS, ...);`.

If at the moment `TS = True`, this assigment will clean `TS`, but this is not what we want here.