### PR TITLE
Send ARP requests event when ARP packet Queue if full

### DIFF
--- a/src/net-protos-arp.ads
+++ b/src/net-protos-arp.ads
@@ -47,7 +47,7 @@ package Net.Protos.Arp is
    ARPOP_INVREQUEST : constant Uint16 := 8;
    ARPOP_INVREPLY   : constant Uint16 := 8;
 
-   type Arp_Status is (ARP_FOUND, ARP_PENDING, ARP_NEEDED, ARP_QUEUE_FULL, ARP_UNREACHABLE);
+   type Arp_Status is (ARP_FOUND, ARP_PENDING, ARP_QUEUE_FULL, ARP_UNREACHABLE);
 
    procedure Request (Ifnet     : in out Net.Interfaces.Ifnet_Type'Class;
                       Source_Ip : in Ip_Addr;

--- a/src/net-protos-ipv4.adb
+++ b/src/net-protos-ipv4.adb
@@ -52,7 +52,7 @@ package body Net.Protos.IPv4 is
             Ifnet.Send (Packet);
             Status := EOK;
 
-         when Net.Protos.Arp.ARP_PENDING | Net.Protos.Arp.ARP_NEEDED =>
+         when Net.Protos.Arp.ARP_PENDING =>
             Status := EINPROGRESS;
 
          when Net.Protos.Arp.ARP_UNREACHABLE | Net.Protos.Arp.ARP_QUEUE_FULL =>


### PR DESCRIPTION
Consider case when an application sends packes continuosly. If APR doesn't response for first 3 request, ARP entry queue becomes full. Before this patch we had no more ARP requests in this case.

Also change `Retry > 5` in `Timeout` to be consistent with `Resolve` to use `ARP_MAX_RETRY`.

Fix #19 